### PR TITLE
Switch to use importlib to extract metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Added
+ - Test Python 3.12 with pytest 8.3 and 8.4
 
+### Changed
+ - Switch to use importlib instead of pkg_resources to extract metadata.
+   No need to support Python < 3.8 so no fallback option is provided.
+ - Always depend on setuptools in tox.ini regardless of python version
 
 ## [1.1.1] — 2024-06-12
 ### Fixed

--- a/pytest_common_subject/__init__.py
+++ b/pytest_common_subject/__init__.py
@@ -1,4 +1,4 @@
-import pkg_resources
+from importlib.metadata import version
 
 from .exceptions import DeferredCommonSubjectRvalUsage
 from .fixtures import precondition_fixture
@@ -8,7 +8,7 @@ from .mixins import (
     WithCommonSubjectDeferred,
 )
 
-__version__ = pkg_resources.get_distribution('pytest-common-subject').version
+__version__ = version('pytest-common-subject')
 
 __all__ = [
     'DeferredCommonSubjectRvalUsage',

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 envlist =
   py{  38, 39}-pytest{36,39,40,44,45,46,50,51,52,53,54,60,61,62,70,71}
   py{ 310,311}-pytest{                                       62,70,71,72,73,74,80,81,82}
-  py{     312}-pytest{                                                   73,74,80,81,82}
-
+  py{     312}-pytest{                                                   73,74,80,81,82,83,84}
 
 [testenv]
 allowlist_externals =
@@ -38,10 +37,17 @@ deps =
   pytest80: pytest~=8.0.0
   pytest81: pytest~=8.1.0
   pytest82: pytest~=8.2.0
+  pytest83: pytest~=8.3.0
+  pytest84: pytest~=8.4.0
 
-  # Python 3.12 virtualenvs appear to sometimes suffer from a missing setuptools,
-  # leading to errors like "ModuleNotFoundError: No module named 'pkg_resources'"
-  py312: setuptools
+  # Python 3.12 virtualenvs do not install setuptools by default.
+  # In addition, from pytest 4.6 pytest exposes metadata which tox uses to create
+  # an isolated environment.  Thus without a dependency on setuptools, the environment
+  # will not contain setuptools, and hence pkg_resources, leading to errors like
+  # "ModuleNotFoundError: No module named 'pkg_resources'".
+  # Required until pytest_fixture_order dependency also removes reliance on
+  # pkg_resources.
+  setuptools
 
 install_command =
   {toxinidir}/_tox_install_command.sh {opts} {packages}


### PR DESCRIPTION
pkg_resources is deprecated and scheduled for removal.  Replace its usage with importlib (with a fallback for python < 3.8).

Also, add testing using pytest 8.3, 8.4 for python 3.12.

Finally, always depend on setuptools for testing.  The comments in tox.ini provide the reasoning.